### PR TITLE
Include babel transpilation ES6 -> ES5

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": [
+        ["es2015", {"modules": false}]
+    ],
+    "plugins": ["external-helpers"]
+}

--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,11 @@
     "innerself": "^0.1.1"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
     "rollup": "^0.50.0",
+    "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-livereload": "^0.6.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-serve": "^0.4.2",

--- a/template/rollup.config.js
+++ b/template/rollup.config.js
@@ -3,6 +3,7 @@ import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
 import typescript from 'rollup-plugin-typescript2';
 import uglify from 'rollup-plugin-uglify';
+import babel from 'rollup-plugin-babel';
 import { minify } from 'uglify-es';
 
 const prod = process.env.NODE_ENV === 'production';
@@ -17,7 +18,8 @@ export default {
       : [
           serve({ contentBase: 'public', historyApiFallback: true }),
           livereload()
-        ])
+      ]),
+      babel()
   ],
   output: {
     file: 'public/bundle.js',


### PR DESCRIPTION
This should close #1.

This transpiles all the generated ES6 down to ES5 but DOES NOT include polyfills for `Promise` or `fetch`.